### PR TITLE
fix:dane-gambrell

### DIFF
--- a/dane-gambrell.html
+++ b/dane-gambrell.html
@@ -194,7 +194,7 @@
             <div class="e-main-content">
                 <p v-html="memberData.bio"></p>
 
-                <div class="e-collapsed" v-if="combinedPublications || (memberData.projects && memberData.projects.length)">
+                <div class="e-collapsed" v-if="combinedPublications || otherWorks || (memberData.projects && memberData.projects.length)">
 
                     <template v-if="combinedPublications">
                       <p v-if="!publications_toggle"><span class="b-button m-naked js-articles-toggle" @click="toggle('publications')">Publications &amp; Writing <i
@@ -202,6 +202,14 @@
                       <p v-if="publications_toggle"><span class="b-button m-naked js-articles-toggle" @click="toggle('publications')">Publications &amp; Writing <i
                                   class="material-icons">keyboard_arrow_up</i></span></p>
                       <div class="e-selected-articles project_list" v-if="publications_toggle" v-html="combinedPublications"></div>
+                    </template>
+
+                    <template v-if="otherWorks">
+                      <p v-if="!other_works_toggle"><span class="b-button m-naked js-other-works-toggle" @click="toggle('other_works')">Other Works <i
+                                  class="material-icons">keyboard_arrow_down</i></span></p>
+                      <p v-if="other_works_toggle"><span class="b-button m-naked js-other-works-toggle" @click="toggle('other_works')">Other Works <i
+                                  class="material-icons">keyboard_arrow_up</i></span></p>
+                      <div class="e-selected-articles project_list" v-if="other_works_toggle" v-html="otherWorks"></div>
                     </template>
 
                     <template v-if="memberData.projects && memberData.projects.length">

--- a/dane-gambrell.html
+++ b/dane-gambrell.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 
 
-<meta content="The GovLab | Caleb Gayle" property="og:title" />
+<meta content="The GovLab | Dane Gambrell" property="og:title" />
 <meta
-    content="Caleb Gayle is a Senior Fellow at the Burnes Center for Global Impact and its partner project, The GovLab"
+    content="Dane Gambrell is a Research Fellow at the Burnes Center for Global Impact and its partner project, The GovLab"
     property="og:description">
 
     <meta property="og:type" content="website" />
@@ -89,7 +89,7 @@
 
     
 
-<div class="b-fancy-bio" id="teamdetail">
+<div class="b-fancy-bio" id="teamdetail" v-cloak>
     <div class="b-top-section">
         <div class="e-wrap">
             <div v-if="memberData.picture" class="e-pic" :style="{ backgroundImage: 'url(' +client.url+'assets/'+  memberData.picture.id+ ')' }">
@@ -159,7 +159,7 @@
                     </ul>
 
                 </section> -->
-                <section class="e-section">
+                <section class="e-section" v-if="memberData.books && memberData.books.length">
                     <h3>By {{memberData.name}}</h3>
 
                     <ul class="e-books"  v-for= "(book, index) in memberData.books">
@@ -194,8 +194,25 @@
             <div class="e-main-content">
                 <p v-html="memberData.bio"></p>
 
-                
+                <div class="e-collapsed" v-if="combinedPublications || (memberData.projects && memberData.projects.length)">
 
+                    <template v-if="combinedPublications">
+                      <p v-if="!publications_toggle"><span class="b-button m-naked js-articles-toggle" @click="toggle('publications')">Publications &amp; Writing <i
+                                  class="material-icons">keyboard_arrow_down</i></span></p>
+                      <p v-if="publications_toggle"><span class="b-button m-naked js-articles-toggle" @click="toggle('publications')">Publications &amp; Writing <i
+                                  class="material-icons">keyboard_arrow_up</i></span></p>
+                      <div class="e-selected-articles project_list" v-if="publications_toggle" v-html="combinedPublications"></div>
+                    </template>
+
+                    <template v-if="memberData.projects && memberData.projects.length">
+                      <div class="b-button m-naked js-project-toggle" v-if="!projects_toggle" @click="toggle('projects')">Projects <i class="material-icons">keyboard_arrow_down</i></div>
+                      <div class="b-button m-naked js-project-toggle" v-if="projects_toggle" @click="toggle('projects')">Projects <i class="material-icons">keyboard_arrow_up</i></div>
+                      <ul class="e-projects project_list" v-if="projects_toggle">
+                        <li v-for="project in memberData.projects"><a :href="projectHref(project)" target="_blank">{{project.projects_id.name}}</a></li>
+                      </ul>
+                    </template>
+
+                </div>
 
             </div>
         </div>

--- a/static/js/team_detail.js
+++ b/static/js/team_detail.js
@@ -41,10 +41,10 @@ new Vue({
       twitter_title:'',
       twitter_image:'',
       twitter_desc:'',
-      // apiURL: 'https://directus.thegovlab.com/thegovlab/items/team?filter[slug][like]=',
       apiURL: 'https://burnes-center.directus.app/items/team?filter[slug][like]=',
       apiApp: '&fields=*.*,books.books_id.*,videos.directus_files_id.*,projects.projects_id.*',
-      combinedPublications: '' // Store combined publications + blogs
+      combinedPublications: '',
+      rebootTeamId: null
 
     }
   },
@@ -56,9 +56,7 @@ metaInfo () {
       {name: 'twitter:card', content: 'summary_large_image'},
        {name: 'twitter:title', content: this.meta_title},
        {name: 'twitter:description', content: this.meta_content},
-       // image must be an absolute path
        {name: 'twitter:image', content: this.meta_image},
-       // Facebook OpenGraph
        {property: 'og:title', content: this.meta_title},
        {property: 'og:site_name', content: this.meta_title},
        {property: 'og:type', content: 'website'},
@@ -102,152 +100,256 @@ metaInfo () {
     }
   }
 ).then(data => {
-  console.log(data)
-  // Sort books
-  data.data[0].books.sort(function(a, b) {
-    var textA = a.books_id.title.toUpperCase();
-    var textB = b.books_id.title.toUpperCase();
-    return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;
-});
-  // Sort talks
-  data.data[0].bio_events.sort(function(a, b) {
-
-    var textA = moment(a.events_id.from).format('X');
-    var textB = moment(b.events_id.from).format('X');
-    if(textA == 'Invalid date')textA = '1357018200';
-    if(textB == 'Invalid date')textB = '1357018200';
-    
-    return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;
-});
-console.log(data.data[0].bio_events);
-data.data[0].bio_events.reverse();
-console.log('data', data.data[0].bio_events);
+  if (!data.data || !data.data[0]) {
+    return;
+  }
+  if (data.data[0].books) {
+    data.data[0].books.sort(function(a, b) {
+      var textA = a.books_id.title.toUpperCase();
+      var textB = b.books_id.title.toUpperCase();
+      return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;
+    });
+  }
+  if (data.data[0].bio_events) {
+    data.data[0].bio_events.sort(function(a, b) {
+      var textA = moment(a.events_id.from).format('X');
+      var textB = moment(b.events_id.from).format('X');
+      if(textA == 'Invalid date')textA = '1357018200';
+      if(textB == 'Invalid date')textB = '1357018200';
+      return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;
+    });
+    data.data[0].bio_events.reverse();
+  }
 
   self.memberData = data.data[0];
   self.meta_title = 'The Govlab '+self.memberData.name;
   self.meta_content = self.memberData.bio_short;
   self.meta_image = self.memberData.picture;
-  
-  // Fetch blogs for this team member and combine with publications
+
   self.fetchBlogsAndCombine();
 })
 .catch(error => console.error(error));
     },
-    
-    fetchBlogsAndCombine() {
-      self = this;
-    
-      this.client.getItems(
-        'reboot_democracy_blog',
-        {
-          limit: -1,
-          sort: '-date',
-          fields: ['*.*', 'authors.*']
+
+    hasTeamPublicationsHtml() {
+      const pubs = this.memberData.publications;
+      return pubs && pubs !== 'NULL' && String(pubs).trim().length > 0;
+    },
+
+    parseNameParts(fullName) {
+      const parts = (fullName || '').trim().split(/\s+/).filter(Boolean);
+      if (parts.length < 2) {
+        return { firstName: parts[0] || '', lastName: parts[0] || '' };
+      }
+      return {
+        firstName: parts.slice(0, -1).join(' '),
+        lastName: parts[parts.length - 1]
+      };
+    },
+
+    resolveRebootTeamId() {
+      const self = this;
+      const nameParts = this.parseNameParts(this.memberData.name);
+
+      return this.client.getItems('Reboot_Democracy_team', {
+        limit: 1,
+        fields: ['id', 'First_Name', 'Last_Name'],
+        filter: {
+          First_Name: { _eq: nameParts.firstName },
+          Last_Name: { _eq: nameParts.lastName }
         }
-      ).then(blogData => {
-        const cutoffDate = new Date('2025-10-07');
-        const today = new Date();
-        today.setHours(23, 59, 59, 999); // End of today
-        
-        const filteredBlogs = blogData.data.filter(blog => {
-          if (!blog.authors || !Array.isArray(blog.authors)) {
-            return false;
-          }
-          
-          // Check if author has team_id === 1
-          const hasTeamId1 = blog.authors.some(author => author.team_id === 1);
-          if (!hasTeamId1) {
-            return false;
-          }
-          
-          const blogDate = blog.date || blog.date2;
-          if (!blogDate) {
-            return false;
-          }
-          
-          const blogDateObj = new Date(blogDate);
-          return blogDateObj > cutoffDate && blogDateObj <= today;
-        });
-        
-        const publicationsHTML = self.memberData.publications || '';
-        const allItems = [];
-        
-        // Parse publications from HTML
-        if (publicationsHTML) {
-          const tempDiv = document.createElement('div');
-          tempDiv.innerHTML = publicationsHTML;
-          const pubListItems = tempDiv.querySelectorAll('li');
-          
-          pubListItems.forEach(li => {
-            const html = li.outerHTML;
-            const text = li.textContent || li.innerText || '';
-            
-            let date = null;
-            const dateMatch = text.match(/(\d{4})/);
-            if (dateMatch) {
-              const year = parseInt(dateMatch[1]);
-              const fullDateMatch = text.match(/(\w+\s+\d{1,2},?\s+\d{4})/i) || text.match(/(\d{1,2}\/\d{1,2}\/\d{4})/);
-              if (fullDateMatch) {
-                date = moment(fullDateMatch[1]).toDate();
-              } else {
-                date = new Date(year, 0, 1);
-              }
-            }
-            
-            allItems.push({
-              html: html,
-              date: date,
-              type: 'publication'
-            });
-          });
-        }
-        
-        // Add blogs to the items array
-        filteredBlogs.forEach(blog => {
-          const blogTitle = blog.title || 'Untitled';
-          const blogLink = blog.fullURL || blog.external_link || (blog.slug ? `https://rebootdemocracy.ai/blog/${blog.slug}` : '#');
-          const blogSource = 'Reboot Democracy';
-          const blogDate = blog.date || blog.date2;
-          const formattedDate = blogDate ? moment(blogDate).format('MMMM D, YYYY') : '';
-          const date = blogDate ? new Date(blogDate) : null;
-          
-          allItems.push({
-            html: `<li><a href="${blogLink}" target="_blank">${blogTitle}</a>, ${blogSource}${formattedDate ? `, ${formattedDate}` : ''}</li>`,
-            date: date,
-            type: 'blog'
-          });
-        });
-        
-        // Sort all items by date (most recent first)
-        allItems.sort((a, b) => {
-          // Items without dates go to the end
-          if (!a.date && !b.date) return 0;
-          if (!a.date) return 1;
-          if (!b.date) return -1;
-          return new Date(b.date) - new Date(a.date);
-        });
-        
-        // Generate combined HTML
-        let combinedHTML = '';
-        allItems.forEach(item => {
-          combinedHTML += item.html;
-        });
-        
-        if (combinedHTML && !combinedHTML.trim().startsWith('<ul')) {
-          self.combinedPublications = `<ul>${combinedHTML}</ul>`;
-        } else {
-          self.combinedPublications = combinedHTML || publicationsHTML;
-        }
-      })
-      .catch(error => {
-        console.error('Error fetching Reboot Democracy Blog:', error);
-        self.combinedPublications = self.memberData.publications || '';
+      }).then(function (data) {
+        self.rebootTeamId = data.data && data.data[0] ? data.data[0].id : null;
+        return self.rebootTeamId;
+      }).catch(function () {
+        self.rebootTeamId = null;
+        return null;
       });
     },
+
+    fetchPublicationsFromCollection() {
+      const self = this;
+      const memberName = (self.memberData.name || '').trim();
+      if (!memberName) {
+        return Promise.resolve([]);
+      }
+
+      return this.client.getItems('publications', {
+        limit: -1,
+        sort: '-pub_date',
+        fields: ['id', 'title', 'authors', 'pub_date', 'url', 'status'],
+        filter: {
+          authors: { _icontains: memberName },
+          status: { _eq: 'published' }
+        }
+      }).then(function (data) {
+        return data.data || [];
+      }).catch(function (error) {
+        console.error('Error fetching publications collection:', error);
+        return [];
+      });
+    },
+
+    publicationItemsFromHtml(publicationsHTML) {
+      const allItems = [];
+      if (!publicationsHTML) {
+        return allItems;
+      }
+
+      const tempDiv = document.createElement('div');
+      tempDiv.innerHTML = publicationsHTML;
+      const pubListItems = tempDiv.querySelectorAll('li');
+
+      pubListItems.forEach(function (li) {
+        const html = li.outerHTML;
+        const text = li.textContent || li.innerText || '';
+        let date = null;
+        const dateMatch = text.match(/(\d{4})/);
+        if (dateMatch) {
+          const year = parseInt(dateMatch[1], 10);
+          const fullDateMatch = text.match(/(\w+\s+\d{1,2},?\s+\d{4})/i) || text.match(/(\d{1,2}\/\d{1,2}\/\d{4})/);
+          if (fullDateMatch) {
+            date = moment(fullDateMatch[1]).toDate();
+          } else {
+            date = new Date(year, 0, 1);
+          }
+        }
+        allItems.push({ html: html, date: date, type: 'publication' });
+      });
+
+      return allItems;
+    },
+
+    publicationItemsFromCollection(pubs) {
+      return pubs.map(function (pub) {
+        const title = pub.title || 'Untitled';
+        const url = pub.url || '#';
+        const authors = pub.authors ? ', ' + pub.authors : '';
+        const formattedDate = pub.pub_date ? moment(pub.pub_date).format('MMMM D, YYYY') : '';
+        const date = pub.pub_date ? new Date(pub.pub_date) : null;
+        return {
+          html: '<li><a href="' + url + '" target="_blank">' + title + '</a>' + authors + (formattedDate ? ', ' + formattedDate : '') + '</li>',
+          date: date,
+          type: 'publication'
+        };
+      });
+    },
+
+    blogItemsFromPosts(blogs) {
+      return blogs.map(function (blog) {
+        const blogTitle = blog.title || 'Untitled';
+        const blogLink = blog.fullURL || blog.external_link || (blog.slug ? 'https://rebootdemocracy.ai/blog/' + blog.slug : '#');
+        const blogSource = 'Reboot Democracy';
+        const blogDate = blog.date || blog.date2;
+        const formattedDate = blogDate ? moment(blogDate).format('MMMM D, YYYY') : '';
+        const date = blogDate ? new Date(blogDate) : null;
+        return {
+          html: '<li><a href="' + blogLink + '" target="_blank">' + blogTitle + '</a>, ' + blogSource + (formattedDate ? ', ' + formattedDate : '') + '</li>',
+          date: date,
+          type: 'blog'
+        };
+      });
+    },
+
+    buildCombinedPublicationsHtml(allItems, fallbackHtml) {
+      allItems.sort(function (a, b) {
+        if (!a.date && !b.date) return 0;
+        if (!a.date) return 1;
+        if (!b.date) return -1;
+        return new Date(b.date) - new Date(a.date);
+      });
+
+      let combinedHTML = '';
+      allItems.forEach(function (item) {
+        combinedHTML += item.html;
+      });
+
+      if (combinedHTML && !combinedHTML.trim().startsWith('<ul')) {
+        return '<ul>' + combinedHTML + '</ul>';
+      }
+      return combinedHTML || fallbackHtml || '';
+    },
+
+    fetchBlogsAndCombine() {
+      const self = this;
+      self.resolveRebootTeamId().then(function (rebootTeamId) {
+        const blogPromise = self.client.getItems('reboot_democracy_blog', {
+          limit: -1,
+          sort: '-date',
+          fields: ['*', 'authors.*'],
+          filter: {
+            status: { _eq: 'published' }
+          }
+        });
+
+        const pubsPromise = self.hasTeamPublicationsHtml()
+          ? Promise.resolve([])
+          : self.fetchPublicationsFromCollection();
+
+        return Promise.all([blogPromise, pubsPromise]).then(function (results) {
+          const blogData = results[0];
+          const collectionPubs = results[1];
+          const allItems = [];
+
+          if (self.hasTeamPublicationsHtml()) {
+            allItems.push.apply(allItems, self.publicationItemsFromHtml(self.memberData.publications));
+          } else {
+            allItems.push.apply(allItems, self.publicationItemsFromCollection(collectionPubs));
+          }
+
+          const filteredBlogs = (blogData.data || []).filter(function (blog) {
+            if (!blog.authors || !Array.isArray(blog.authors) || !rebootTeamId) {
+              return false;
+            }
+            if ((blog.status || '').toLowerCase() !== 'published') {
+              return false;
+            }
+            return blog.authors.some(function (author) {
+              return author.team_id === rebootTeamId;
+            });
+          });
+
+          allItems.push.apply(allItems, self.blogItemsFromPosts(filteredBlogs));
+
+          const fallback = self.hasTeamPublicationsHtml() ? self.memberData.publications : '';
+          self.combinedPublications = self.buildCombinedPublicationsHtml(allItems, fallback);
+        });
+      }).catch(function (error) {
+        console.error('Error fetching publications and Reboot blog posts:', error);
+        self.combinedPublications = self.hasTeamPublicationsHtml() ? self.memberData.publications : '';
+      });
+    },
+
+    assetUrl(file) {
+      if (!file || file === 'NULL') {
+        return null;
+      }
+      const id = typeof file === 'object' && file.id ? file.id : file;
+      if (!id || !this.client || !this.client.url) {
+        return null;
+      }
+      return this.client.url + 'assets/' + id;
+    },
+
+    highResPhotoUrl() {
+      return this.assetUrl(this.memberData.high_resolution_photo);
+    },
+
+    hasHighResPhoto() {
+      return !!this.highResPhotoUrl();
+    },
+
+    projectHref(project) {
+      if (!project || !project.projects_id) {
+        return '#';
+      }
+      const p = project.projects_id;
+      return p.project_link || p.link || (p.slug ? './' + p.slug + '.html' : '#');
+    },
+
     toggle(key) {
       if(this[key+'_toggle'] == false) this[key+'_toggle'] = true;
       else this[key+'_toggle'] = false;
-      console.log(this[key+'_toggle']);
     },
     teamMore(slug) {
       window.location.href= './' + slug+'.html';

--- a/static/js/team_detail.js
+++ b/static/js/team_detail.js
@@ -44,7 +44,10 @@ new Vue({
       apiURL: 'https://burnes-center.directus.app/items/team?filter[slug][like]=',
       apiApp: '&fields=*.*,books.books_id.*,videos.directus_files_id.*,projects.projects_id.*',
       combinedPublications: '',
-      rebootTeamId: null
+      otherWorks: '',
+      rebootTeamId: null,
+      pawTeamId: null,
+      other_works_toggle: false
 
     }
   },
@@ -120,6 +123,32 @@ metaInfo () {
     });
     data.data[0].bio_events.reverse();
   }
+  if (data.data[0].projects) {
+    data.data[0].projects.sort(function(a, b) {
+      var textA = moment(a.projects_id.created_on).format('X');
+      var textB = moment(b.projects_id.created_on).format('X');
+      if(textA == 'Invalid date') textA = '0';
+      if(textB == 'Invalid date') textB = '0';
+      return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;
+    });
+    data.data[0].projects.reverse();
+
+    var seenProjectIds = {};
+    var seenProjectNames = {};
+    data.data[0].projects = data.data[0].projects.filter(function(project) {
+      if (!project.projects_id) {
+        return false;
+      }
+      var projectId = project.projects_id.id;
+      var projectName = (project.projects_id.name || '').trim().toLowerCase();
+      if (seenProjectIds[projectId] || seenProjectNames[projectName]) {
+        return false;
+      }
+      seenProjectIds[projectId] = true;
+      seenProjectNames[projectName] = true;
+      return true;
+    });
+  }
 
   self.memberData = data.data[0];
   self.meta_title = 'The Govlab '+self.memberData.name;
@@ -127,6 +156,7 @@ metaInfo () {
   self.meta_image = self.memberData.picture;
 
   self.fetchBlogsAndCombine();
+  self.fetchOtherWorks();
 })
 .catch(error => console.error(error));
     },
@@ -145,6 +175,26 @@ metaInfo () {
         firstName: parts.slice(0, -1).join(' '),
         lastName: parts[parts.length - 1]
       };
+    },
+
+    resolvePawTeamId() {
+      const self = this;
+      const nameParts = this.parseNameParts(this.memberData.name);
+
+      return this.client.getItems('paw_team', {
+        limit: 1,
+        fields: ['id', 'First_Name', 'Last_Name'],
+        filter: {
+          First_Name: { _eq: nameParts.firstName },
+          Last_Name: { _eq: nameParts.lastName }
+        }
+      }).then(function (data) {
+        self.pawTeamId = data.data && data.data[0] ? data.data[0].id : null;
+        return self.pawTeamId;
+      }).catch(function () {
+        self.pawTeamId = null;
+        return null;
+      });
     },
 
     resolveRebootTeamId() {
@@ -190,7 +240,22 @@ metaInfo () {
       });
     },
 
+    isExcludedPublication(text) {
+      return (text || '').toLowerCase().indexOf('news that caught our eye') !== -1;
+    },
+
+    filterPublicationItems(items) {
+      const self = this;
+      return items.filter(function (item) {
+        const tempDiv = document.createElement('div');
+        tempDiv.innerHTML = item.html;
+        const text = tempDiv.textContent || tempDiv.innerText || '';
+        return !self.isExcludedPublication(text);
+      });
+    },
+
     publicationItemsFromHtml(publicationsHTML) {
+      const self = this;
       const allItems = [];
       if (!publicationsHTML) {
         return allItems;
@@ -201,8 +266,11 @@ metaInfo () {
       const pubListItems = tempDiv.querySelectorAll('li');
 
       pubListItems.forEach(function (li) {
-        const html = li.outerHTML;
         const text = li.textContent || li.innerText || '';
+        if (self.isExcludedPublication(text)) {
+          return;
+        }
+        const html = li.outerHTML;
         let date = null;
         const dateMatch = text.match(/(\d{4})/);
         if (dateMatch) {
@@ -221,7 +289,10 @@ metaInfo () {
     },
 
     publicationItemsFromCollection(pubs) {
-      return pubs.map(function (pub) {
+      const self = this;
+      return pubs.filter(function (pub) {
+        return !self.isExcludedPublication(pub.title);
+      }).map(function (pub) {
         const title = pub.title || 'Untitled';
         const url = pub.url || '#';
         const authors = pub.authors ? ', ' + pub.authors : '';
@@ -235,8 +306,39 @@ metaInfo () {
       });
     },
 
-    blogItemsFromPosts(blogs) {
+    getPawBlogTranslation(blog) {
+      const translations = blog.translations || [];
+      return translations.find(function (translation) {
+        return translation.languages_code === 'en-US';
+      }) || translations.find(function (translation) {
+        return translation.slug;
+      }) || translations[0] || {};
+    },
+
+    pawBlogItemsFromPosts(blogs) {
+      const self = this;
       return blogs.map(function (blog) {
+        const translation = self.getPawBlogTranslation(blog);
+        const title = translation.title || 'Untitled';
+        const slug = translation.slug;
+        const blogLink = slug ? 'https://poweratwork.us/' + slug : '#';
+        const blogSource = 'Power At Work';
+        const blogDate = blog.publication_date;
+        const formattedDate = blogDate ? moment(blogDate).format('MMMM D, YYYY') : '';
+        const date = blogDate ? new Date(blogDate) : null;
+        return {
+          html: '<li><a href="' + blogLink + '" target="_blank">' + title + '</a>, ' + blogSource + (formattedDate ? ', ' + formattedDate : '') + '</li>',
+          date: date,
+          type: 'paw_blog'
+        };
+      });
+    },
+
+    blogItemsFromPosts(blogs) {
+      const self = this;
+      return blogs.filter(function (blog) {
+        return !self.isExcludedPublication(blog.title);
+      }).map(function (blog) {
         const blogTitle = blog.title || 'Untitled';
         const blogLink = blog.fullURL || blog.external_link || (blog.slug ? 'https://rebootdemocracy.ai/blog/' + blog.slug : '#');
         const blogSource = 'Reboot Democracy';
@@ -251,13 +353,15 @@ metaInfo () {
       });
     },
 
-    buildCombinedPublicationsHtml(allItems, fallbackHtml) {
-      allItems.sort(function (a, b) {
-        if (!a.date && !b.date) return 0;
-        if (!a.date) return 1;
-        if (!b.date) return -1;
-        return new Date(b.date) - new Date(a.date);
-      });
+    buildCombinedPublicationsHtml(allItems, fallbackHtml, sortByDate) {
+      if (sortByDate !== false) {
+        allItems.sort(function (a, b) {
+          if (!a.date && !b.date) return 0;
+          if (!a.date) return 1;
+          if (!b.date) return -1;
+          return new Date(b.date) - new Date(a.date);
+        });
+      }
 
       let combinedHTML = '';
       allItems.forEach(function (item) {
@@ -268,6 +372,58 @@ metaInfo () {
         return '<ul>' + combinedHTML + '</ul>';
       }
       return combinedHTML || fallbackHtml || '';
+    },
+
+    buildListHtmlFromItems(items) {
+      if (!items.length) {
+        return '';
+      }
+
+      let listHtml = '';
+      items.forEach(function (item) {
+        listHtml += item.html;
+      });
+      return '<ul>' + listHtml + '</ul>';
+    },
+
+    buildOtherWorksHtml(publicationItems, pawItems) {
+      let html = this.buildListHtmlFromItems(publicationItems);
+
+      if (publicationItems.length && pawItems.length) {
+        html += '<p class="e-other-works-heading"><strong>Power At Work</strong></p>';
+      }
+
+      html += this.buildListHtmlFromItems(pawItems);
+      return html;
+    },
+
+    fetchOtherWorks() {
+      const self = this;
+      const publicationItems = self.hasTeamPublicationsHtml()
+        ? self.filterPublicationItems(self.publicationItemsFromHtml(self.memberData.publications))
+        : [];
+
+      self.resolvePawTeamId().then(function (pawTeamId) {
+        const pawPromise = pawTeamId
+          ? self.client.getItems('paw_blog', {
+              limit: -1,
+              sort: '-publication_date',
+              fields: ['id', 'status', 'publication_date', 'translations.title', 'translations.slug', 'translations.languages_code', 'author.paw_team_id'],
+              filter: {
+                status: { _eq: 'published' },
+                author: { paw_team_id: { _eq: pawTeamId } }
+              }
+            })
+          : Promise.resolve({ data: [] });
+
+        return pawPromise.then(function (data) {
+          const pawItems = self.pawBlogItemsFromPosts(data.data || []);
+          self.otherWorks = self.buildOtherWorksHtml(publicationItems, pawItems);
+        });
+      }).catch(function (error) {
+        console.error('Error fetching Power At Work blog posts:', error);
+        self.otherWorks = self.buildOtherWorksHtml(publicationItems, []);
+      });
     },
 
     fetchBlogsAndCombine() {
@@ -282,20 +438,14 @@ metaInfo () {
           }
         });
 
-        const pubsPromise = self.hasTeamPublicationsHtml()
-          ? Promise.resolve([])
-          : self.fetchPublicationsFromCollection();
+        const pubsPromise = self.fetchPublicationsFromCollection();
 
         return Promise.all([blogPromise, pubsPromise]).then(function (results) {
           const blogData = results[0];
           const collectionPubs = results[1];
           const allItems = [];
 
-          if (self.hasTeamPublicationsHtml()) {
-            allItems.push.apply(allItems, self.publicationItemsFromHtml(self.memberData.publications));
-          } else {
-            allItems.push.apply(allItems, self.publicationItemsFromCollection(collectionPubs));
-          }
+          allItems.push.apply(allItems, self.publicationItemsFromCollection(collectionPubs));
 
           const filteredBlogs = (blogData.data || []).filter(function (blog) {
             if (!blog.authors || !Array.isArray(blog.authors) || !rebootTeamId) {
@@ -311,12 +461,12 @@ metaInfo () {
 
           allItems.push.apply(allItems, self.blogItemsFromPosts(filteredBlogs));
 
-          const fallback = self.hasTeamPublicationsHtml() ? self.memberData.publications : '';
-          self.combinedPublications = self.buildCombinedPublicationsHtml(allItems, fallback);
+          const filteredItems = self.filterPublicationItems(allItems);
+          self.combinedPublications = self.buildCombinedPublicationsHtml(filteredItems, '');
         });
       }).catch(function (error) {
         console.error('Error fetching publications and Reboot blog posts:', error);
-        self.combinedPublications = self.hasTeamPublicationsHtml() ? self.memberData.publications : '';
+        self.combinedPublications = '';
       });
     },
 

--- a/static/styles/customstyles.css
+++ b/static/styles/customstyles.css
@@ -7,3 +7,9 @@
 {
   
 }
+
+#teamdetail .e-other-works-heading {
+  margin: 1.25rem 0 0.75rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> `team_detail.js` changes affect every team page that loads it: new Directus queries and name-based ID resolution could show wrong or missing publications if CMS data or names do not align.
> 
> **Overview**
> Adds **Dane Gambrell**’s team bio page with expandable **Publications & Writing**, **Other Works**, and **Projects**, and refactors shared `team_detail.js` behavior used across team profiles.
> 
> **Publications & Writing** now merges the Directus `publications` collection (by author name, published only) with **Reboot Democracy** posts tied to the member via `Reboot_Democracy_team` name lookup—not a fixed `team_id`. **Other Works** combines legacy `publications` HTML from the team record with **Power At Work** posts matched through `paw_team`. Projects are sorted by `created_on` and deduplicated by id/name.
> 
> **High-res downloads** use `high_resolution_photo` through `hasHighResPhoto()` / `highResPhotoUrl()`; `anirudh-dinesh.html` adopts the same pattern and a delegated GA click handler on `.js-high-res-photo-download`. Minor CSS for the Power At Work subheading in Other Works.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6d2988bbe805a886dba706adcdfa5bbb2d8e97a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->